### PR TITLE
Fix AssignTargetTableFields procedure

### DIFF
--- a/IntDataMigrationTool/src/table/PTEMigrationDatasetTable.Table.al
+++ b/IntDataMigrationTool/src/table/PTEMigrationDatasetTable.Table.al
@@ -275,9 +275,8 @@ table 99004 "PTE Migration Dataset Table"
                 if PTEAppObjectTableField.FindFirst() then begin
                     PTEMigrDatasetTableField."Target table name" := TargetTableName;
                     PTEMigrDatasetTableField.Validate("Target Field name", PTEAppObjectTableField.Name);
-                end else
-                    PTEMigrDatasetTableField.Validate("Target Field name", '');
-                PTEMigrDatasetTableField.Modify();
+                    PTEMigrDatasetTableField.Modify();
+                end;
             until PTEMigrDatasetTableField.Next() = 0;
     end;
 


### PR DESCRIPTION
Fix assignment of target table fields in PTE Migration Dataset Table, so that the modify statement is not run for empty records.